### PR TITLE
Make flavor text a little less exuberant

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1500,7 +1500,7 @@ async fn hgive<'a>(slash_command: LenientForm<SlashCommand>) -> Json<Value> {
                         "alt_text": "hackagotchi img",
                     }
                 },
-                comment("EY BRO TAEK DIS N DONT TELL MOM, OwO")
+                comment("TAKE THIS AND DONT TELL MOM")
             ],
             "response_type": "in_channel",
         });
@@ -3206,7 +3206,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
                                         "alt_text": "happy shiny egg give u stuffs",
                                     }
                                 }),
-                                comment("WAT I TAUGHT ET WAZ ROCC!?!?!!"),
+                                comment("WAT I THOUGHT IT WAS ROCK"),
                                 json!({ "type": "divider" }),
                             ];
 


### PR DESCRIPTION
Change the hgive and egg hatch flavor text to better match the tone of the previous flavor texts (in my opinion, anyway).