### PR TITLE
clarify messages in gift DMs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -108,9 +108,10 @@ async fn gift_dm(
     giver: &str,
     new_owner: &str,
     possession: &Possession,
+    notif_msg: String,
     count: usize,
 ) -> Result<(), String> {
-    dm_blocks(new_owner.to_string(), "You've received a gift!".to_string(), {
+    dm_blocks(new_owner.to_string(), notif_msg.to_string(), {
         // TODO: with_capacity optimization
         let mut blocks = vec![
             json!({
@@ -1504,13 +1505,23 @@ async fn hgive<'a>(slash_command: LenientForm<SlashCommand>) -> Json<Value> {
             ],
             "response_type": "in_channel",
         });
+        let notif_msg = format!(
+            "<@{}> sent you {} {}!",
+            user, amount, possession_archetype.name
+        );
 
         tokio::spawn(async move {
             info!("I mean this happens?");
 
-            let _ = gift_dm(&user, &receiver, possessions.first().unwrap(), amount)
-                .await
-                .map_err(|e| error!("{}", e));
+            let _ = gift_dm(
+                &user,
+                &receiver,
+                possessions.first().unwrap(),
+                notif_msg,
+                amount,
+            )
+            .await
+            .map_err(|e| error!("{}", e));
 
             for possession in possessions {
                 match Hacksteader::transfer_possession(
@@ -1975,11 +1986,10 @@ async fn action_endpoint(
 
                 let possession = hacksteader::get_possession(&dyn_db(), key).await?;
                 let notif_msg =
-                    format!("<@{}> has gifted you a {}!", user.id, possession.nickname())
-                        .to_string();
+                    format!("<@{}> has gifted you a {}!", user.id, possession.nickname());
 
                 // DM the new_owner about their new acquisition!
-                gift_dm(&user.id, new_owner, &possession, 1).await?;
+                gift_dm(&user.id, new_owner, &possession, notif_msg, 1).await?;
 
                 // close ALL THE MODALS!!!
                 return Ok(ActionResponse::Json(Json(json!({

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,7 +111,7 @@ async fn gift_dm(
     notif_msg: String,
     count: usize,
 ) -> Result<(), String> {
-    dm_blocks(new_owner.to_string(), notif_msg.to_string(), {
+    dm_blocks(new_owner.to_string(), notif_msg, {
         // TODO: with_capacity optimization
         let mut blocks = vec![
             json!({


### PR DESCRIPTION
Will clarify the amount and type of any certain item in notifications for DMs in response to /hgive or manual give commands.

Also clears up a few of those pesky warnings on compile.
